### PR TITLE
Use `version` arg from base class

### DIFF
--- a/dcm_tagSub/dcm_tagSub.py
+++ b/dcm_tagSub/dcm_tagSub.py
@@ -143,7 +143,7 @@ class Dcm_tagSub(ChrisApp):
                         json                = options.jsonReturn
                     )
 
-        if options.b_version:
+        if options.version:
             print('Plugin Version: %s' % Dcm_tagSub.VERSION)
             print('Internal pfdicom_tagSub Version: %s' % pf_dicom_tagSub.str_version)
             sys.exit(0)


### PR DESCRIPTION
23ceda47eed387abca15d46ac7aec00761e41fd8 removed the `b_version` argument in favor of the one from the parent class, but the `run()` method still accessed `options.b_version`.