### PR TITLE
Offer `tagInfo` param to avoid JSON parsing

### DIFF
--- a/dcm_tagSub/dcm_tagSub.py
+++ b/dcm_tagSub/dcm_tagSub.py
@@ -34,7 +34,7 @@ class Dcm_tagSub(ChrisApp):
     TYPE                    = 'ds'
     DESCRIPTION             = 'This plugin wraps around pfdicom_tagSub and is used to edit the contents of user-specified DICOM tags.'
     DOCUMENTATION           = 'https://github.com/FNNDSC/pl-pfdicom_tagSub'
-    VERSION                 = '2.0.0'
+    VERSION                 = '2.0.2'
     ICON                    = '' # url of an icon image
     LICENSE                 = 'Opensource (MIT)'
     MAX_NUMBER_OF_WORKERS   = 1  # Override with integer value


### PR DESCRIPTION
To avoid issue of JSON parsing when run through CUBE, use parameter `tagInfo` rather than `tagStruct`. It expects a string of `"<key>":"<value>"` pairs delimited by semicolons:

`--tagInfo '"PatientName":"anon";"PatientID":"%_md5|7_PatientID"'`

The regular expression that parses this should be fairly robust to whitespace, so the following is equivalent:

```
--tagInfo '
    "PatientName": "anon";
    "PatientID": "%_md5|7_PatientID"
'
```

